### PR TITLE
Install nextstrain.sphinx.theme extension

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-nextstrain-sphinx-theme >=2022.1
+nextstrain-sphinx-theme >=2022.5
 sphinx

--- a/src/conf.py
+++ b/src/conf.py
@@ -10,3 +10,7 @@ copyright = '2022, Trevor Bedford and Richard Neher'
 author = 'The Nextstrain Team'
 
 html_theme = 'nextstrain-sphinx-theme'
+
+extensions = [
+    'nextstrain.sphinx.theme',
+]


### PR DESCRIPTION
## Description of proposed changes

The new extension has sphinx_copybutton pre-installed and configured. This change enables it here.
This also makes it easier to configure other extensions across multiple docs projects.

## Related issue(s)

https://github.com/nextstrain/sphinx-theme/issues/30

## Testing

- [x] ~copy button works on RTD preview build~ no code block in this project but I have high confidence in this change given similar changes tracked by https://github.com/nextstrain/sphinx-theme/issues/30